### PR TITLE
Save and restore window position and size

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,5 +12,8 @@
   },
   "author": "Marek Hrabe <marekhrabe@abdoc.net> (https://github.com/marekhrabe)",
   "license": "MIT",
-  "atomShellVersion": "0.22.3"
+  "atomShellVersion": "0.22.3",
+  "devDependencies": {
+    "lodash": "^3.6.0"
+  }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,5 @@
+var fs = require('fs');
+var defaults = require('lodash').defaults;
 var app = require('app');
 var ipc = require('ipc');
 var BrowserWindow = require('browser-window');
@@ -8,21 +10,46 @@ var dialog = require('dialog');
 var staticPath = path.join(__dirname, '..', 'static');
 
 var mainWindow = null;
+var runtimeSettingsPath = null;
 
 // App
 app.on('ready', function () {
-  mainWindow = new BrowserWindow({
+  var windowOptions = {
     width: 800,
     height: 600,
     frame: false,
-    resizable: false,
     'web-preferences': {
       plugins: true
     },
     title: 'Loading'
-  });
+  };
 
+  runtimeSettingsPath = path.join(app.getPath('userData'), 'runtimeSettings.json');
+
+  var savedWindowOptions = {};
+  try {
+    savedWindowOptions = JSON.parse(fs.readFileSync(runtimeSettingsPath));
+  } catch(e) {}
+
+  windowOptions = defaults(savedWindowOptions, windowOptions);
+
+  mainWindow = new BrowserWindow(windowOptions);
   mainWindow.loadUrl('file://' + staticPath + '/app.html');
+
+  mainWindow.on('closed', function() {
+    var size = mainWindow.getSize();
+    var position = mainWindow.getPosition();
+    var windowProperties = {
+      x: position[0],
+      y: position[1],
+      width: size[0],
+      height: size[1]
+    };
+    fs.writeFile(runtimeSettingsPath, JSON.stringify(windowProperties), function(err) {
+      app.quit();
+      mainWindow = null;
+    });
+  })
 });
 
 // API


### PR DESCRIPTION
The purpose of this is to remember the size and location of the window when you close the app, and then position it there when you open the app again.

This introduces a few changes that might need some consideration:
- New dependency: `lodash`, for merging settings objects
- A settings-file stored in `~/Library/Application Support/messenger`

When the window closes, an object is saved as JSON to `runtimeSettings.json`, with the following keys:
- `x`
- `y`
- `width`
- `height`

This object is then read when the app starts and used to create the `BrowserWindow`.

Things to consider:
- The code is getting long enough to warrant some isolation
- Is this way to store settings what we want? One file per type of setting, or maybe a `userSettings.json`-file with root keys instead?
  
  ``` json
  {
    "window": {
      "x": 200,
      "y": 300,
      "width": 800,
      "height": 600
    }
  }
  ```

Hopefully this proves useful!
